### PR TITLE
neschan.cpp Adding inline to make_argb

### DIFF
--- a/src/neschan.cpp
+++ b/src/neschan.cpp
@@ -7,7 +7,7 @@
 
 using namespace std;
 
-uint32_t make_argb(uint8_t r, uint8_t g, uint8_t b)
+inline uint32_t make_argb(uint8_t r, uint8_t g, uint8_t b)
 {
     return (r << 16) | (g << 8) | b;
 }


### PR DESCRIPTION
With the inline tag, instead of calling a function (which is a bit slower), the compiler will simply copy the code of the function to gain more speed.