### PR TITLE
Fix assert error.

### DIFF
--- a/lib/inc/nes_memory.h
+++ b/lib/inc/nes_memory.h
@@ -19,7 +19,7 @@ class nes_memory : public nes_component
 public :
     nes_memory()
     {
-        _ram.reserve(RAM_SIZE);
+        _ram.resize(RAM_SIZE);
     }
 
     bool is_io_reg(uint16_t addr)


### PR DESCRIPTION
reserver() method does not change the size of vector. 

Index 0 used in nes_memory::power_on() while vector size was 0.
```cpp
memset(&_ram[0], 0, RAM_SIZE);
```